### PR TITLE
[SDS-934] no wires fails for hw backends

### DIFF
--- a/pennylane_quantuminspire/qi_device.py
+++ b/pennylane_quantuminspire/qi_device.py
@@ -127,7 +127,7 @@ class QuantumInspireDevice(QiskitDevice, ABC):  # type: ignore
     ) -> Union[int, Iterable[int], Iterable[str]]:
         """
         For some backends, the number of wires has to match the number of qubits accessible. Here we add dummy wires
-        when the numbers do not match.
+        when the numbers do not match. Only add dummy wires when initially at least one wire was found.
 
         Args:
             backend_type: the backend (type) information.
@@ -146,7 +146,7 @@ class QuantumInspireDevice(QiskitDevice, ABC):  # type: ignore
             else:
                 all_wires = Wires(wires)
 
-            if len(all_wires) < backend_number_of_qubits:
+            if 0 < len(all_wires) < backend_number_of_qubits:
                 dummy_wires = Wires([f"_dummy-wire-{i}" for i in range(backend_number_of_qubits - len(all_wires))])
                 wires = Wires.all_wires([all_wires, dummy_wires])
 

--- a/tests/unit_test/test_qi_device_unit.py
+++ b/tests/unit_test/test_qi_device_unit.py
@@ -72,7 +72,7 @@ class TestDeviceConfiguration(TestCase):
 
     def test_number_of_wires_less_than_number_of_qubits_hardware_backends_succeed(self, *args):
         """
-        Test that number of wires < number of qubits of hardware backends is supported.
+        Test that number of 0 < wires < number of qubits of hardware backends is supported.
         """
         with patch('pennylane_quantuminspire.qi_device.QiskitDevice.__init__'):
             _ = qml.device("quantuminspire.qi", wires=2, backend="Starmon-5")
@@ -82,8 +82,13 @@ class TestDeviceConfiguration(TestCase):
 
     def test_not_supported_number_of_wires(self, *args):
         """
-        Test wires.
+        Test wires. Fail when we have no wires or more than the capacity of the backend.
         """
+        with pytest.raises(DeviceError) as exc_info:
+            _ = qml.device("quantuminspire.qi", wires=[], backend="Starmon-5")
+
+        assert str(exc_info.value) == 'Invalid number of wires: 0'
+
         with pytest.raises(DeviceError) as exc_info:
             _ = qml.device("quantuminspire.qi", wires=[], backend="QX single-node simulator")
 


### PR DESCRIPTION
* When no wires are given initially, we do not add dummy wires for hardware backends, otherwise we end up with only dummy wires
* Added unit test for this case