### PR TITLE
[SDS-1127] plugin test matrix fails

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,4 +1,4 @@
 pennylane-qiskit>=0.29.0
 quantuminspire>=2.1.0
-qiskit<=0.45.1
+qiskit==0.45.1
 pennylane>=0.30,<0.34

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pennylane-qiskit>=0.29.0
 quantuminspire>=2.1.0
-qiskit<=0.45.1
+qiskit==0.45.1
 pennylane>=0.30,<0.34


### PR DESCRIPTION
Reason why test matrix is failing is because these imports do not succeed with version 0.45 of Qiskit:

from qiskit.providers.backend import BackendV1 as Backend
from qiskit import QuantumCircuit

As soon as package version 1.0.2 is used, these imports succeed and the test will pass.

When uninstalling and reinstalling package 0.45, imports do succeed, so it is the installation that initially fails.

When qiskit is forced to version 0.45.1, installation seems to work.